### PR TITLE
Bump Rubocop to v0.59

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -55,6 +55,8 @@ Metrics/PerceivedComplexity:
 
 Naming/FileName:
   Enabled: false
+Naming/MemoizedInstanceVariableName:
+  EnforcedStyleForLeadingUnderscores: optional
 Naming/UncommunicativeMethodParamName:
   AllowedNames:
     - _

--- a/rubocop-jekyll.gemspec
+++ b/rubocop-jekyll.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.required_ruby_version = ">= 2.3.0"
 
-  s.add_runtime_dependency "rubocop", "~> 0.57.2"
+  s.add_runtime_dependency "rubocop", "~> 0.59.0"
 end


### PR DESCRIPTION
- Allows use of `Rubocop 0.59.x`
- Adds config for `Naming/MemoizedInstanceVariableName`