### PR TITLE
chore(deps): rubocop 0.60.0

### DIFF
--- a/rubocop-jekyll.gemspec
+++ b/rubocop-jekyll.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.required_ruby_version = ">= 2.3.0"
 
-  s.add_runtime_dependency "rubocop", "~> 0.59.0"
+  s.add_runtime_dependency "rubocop", "~> 0.60.0"
 end


### PR DESCRIPTION
Some Jekyll plugins depends on this gem, as we bumped Jekyll to 0.60, I'd like to bump plugins now.