### PR TITLE
Allow using RuboCop v0.61.x

### DIFF
--- a/rubocop-jekyll.gemspec
+++ b/rubocop-jekyll.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.required_ruby_version = ">= 2.3.0"
 
-  s.add_runtime_dependency "rubocop", ">= 0.57.2", "< 0.61.0"
+  s.add_runtime_dependency "rubocop", ">= 0.57.2", "< 0.62.0"
 end


### PR DESCRIPTION
RuboCop v0.61.0 Release Details: https://github.com/rubocop-hq/rubocop/releases/tag/v0.61.0