### PR TITLE
Allow using Rubocop v0.64.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ or if you prefer Bundler, add it to your `Gemfile` or `gemspec`
 ```ruby
 # Gemfile
 
-gem "rubocop-jekyll", "~> 0.6.0"
+gem "rubocop-jekyll", "~> 0.7.0"
 ```
 ```ruby
 # <plugin>.gemspec
 
-spec.add_development_dependency "rubocop-jekyll", "~> 0.6.0"
+spec.add_development_dependency "rubocop-jekyll", "~> 0.7.0"
 ```
 and run `bundle install`
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A RuboCop extension to enforce common code style in Jekyll and Jekyll plugins.
 
 
 [![Gem Version](https://img.shields.io/gem/v/rubocop-jekyll.svg?label=Latest%20Release)][rubygems]
-[![RuboCop Support](https://img.shields.io/badge/Rubocop%20Support-0.57.2%20--%200.63.x-green.svg)][rubocop-releases]
+[![RuboCop Support](https://img.shields.io/badge/Rubocop%20Support-0.57.2%20--%200.64.x-green.svg)][rubocop-releases]
 
 [rubygems]: https://rubygems.org/gems/rubocop-jekyll
 [rubocop-releases]: https://github.com/rubocop-hq/rubocop/releases

--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ or if you prefer Bundler, add it to your `Gemfile` or `gemspec`
 ```ruby
 # Gemfile
 
-gem "rubocop-jekyll", "~> 0.7.0"
+gem "rubocop-jekyll", "~> 0.6.0"
 ```
 ```ruby
 # <plugin>.gemspec
 
-spec.add_development_dependency "rubocop-jekyll", "~> 0.7.0"
+spec.add_development_dependency "rubocop-jekyll", "~> 0.6.0"
 ```
 and run `bundle install`
 

--- a/rubocop-jekyll.gemspec
+++ b/rubocop-jekyll.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift File.expand_path("lib", __dir__)
 
 Gem::Specification.new do |s|
   s.name        = "rubocop-jekyll"
-  s.version     = "0.6.0"
+  s.version     = "0.7.0"
   s.authors     = ["Ashwin Maroli"]
   s.email       = ["ashmaroli@gmail.com"]
   s.homepage    = "https://github.com/ashmaroli/rubocop-jekyll"
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.required_ruby_version = ">= 2.3.0"
 
-  s.add_runtime_dependency "rubocop", ">= 0.57.2", "< 0.64.0"
+  s.add_runtime_dependency "rubocop", ">= 0.57.2", "< 0.65.0"
 end

--- a/rubocop-jekyll.gemspec
+++ b/rubocop-jekyll.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift File.expand_path("lib", __dir__)
 
 Gem::Specification.new do |s|
   s.name        = "rubocop-jekyll"
-  s.version     = "0.7.0"
+  s.version     = "0.6.0"
   s.authors     = ["Ashwin Maroli"]
   s.email       = ["ashmaroli@gmail.com"]
   s.homepage    = "https://github.com/ashmaroli/rubocop-jekyll"


### PR DESCRIPTION
RuboCop v0.64.0 Release Details: https://github.com/rubocop-hq/rubocop/releases/tag/v0.64.0