### PR TITLE
Allow using RuboCop v0.66.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A RuboCop extension to enforce common code style in Jekyll and Jekyll plugins.
 
 
 [![Gem Version](https://img.shields.io/gem/v/rubocop-jekyll.svg?label=Latest%20Release)][rubygems]
-[![RuboCop Support](https://img.shields.io/badge/Rubocop%20Support-0.57.2%20--%200.65.x-green.svg)][rubocop-releases]
+[![RuboCop Support](https://img.shields.io/badge/Rubocop%20Support-0.57.2%20--%200.66.x-green.svg)][rubocop-releases]
 
 [rubygems]: https://rubygems.org/gems/rubocop-jekyll
 [rubocop-releases]: https://github.com/rubocop-hq/rubocop/releases

--- a/rubocop-jekyll.gemspec
+++ b/rubocop-jekyll.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.required_ruby_version = ">= 2.3.0"
 
-  s.add_runtime_dependency "rubocop", ">= 0.57.2", "< 0.66.0"
+  s.add_runtime_dependency "rubocop", ">= 0.57.2", "< 0.67.0"
 end


### PR DESCRIPTION
RuboCop v0.66.0 Release Details: https://github.com/rubocop-hq/rubocop/releases/tag/v0.66.0