### PR TITLE
Target Ruby 2.5

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
 AllCops:
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   Exclude:
     - bin/**/*
     - exe/**/*

--- a/rubocop-jekyll.gemspec
+++ b/rubocop-jekyll.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   end
 
   s.require_paths = ["lib"]
-  s.required_ruby_version = ">= 2.3.0"
+  s.required_ruby_version = ">= 2.4.0"
 
   s.add_runtime_dependency "rubocop", ">= 0.57.2", "< 0.67.0"
 end


### PR DESCRIPTION
Ruby 2.4 is now EOL, Jekyll v4 requires Ruby 2.4, so do core plugins:

`spec.required_ruby_version = ">= 2.4.0"`

That leads our script/fmt script to fail:

```
jekyll-sitemap.gemspec:21:32: C: Gemspec/RequiredRubyVersion: required_ruby_version (2.4, declared in jekyll-sitemap.gemspec) and TargetRubyVersion (2.3, which may be specified in .rubocop.yml) should be equal.
  spec.required_ruby_version = ">= 2.4.0"
                               ^^^^^^^^^^
```

This change aims to make Ruby 2.4 the new default for Jekyll Ruby Style Guide.
