### PR TITLE
Bump supported RuboCop version: v0.68.0 - 0.69.x

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+require:
+  - rubocop-performance
+
 AllCops:
   TargetRubyVersion: 2.3
   Exclude:
@@ -13,9 +16,9 @@ Layout/AlignHash:
   EnforcedHashRocketStyle: table
 Layout/IndentationWidth:
   Severity: error
-Layout/IndentArray:
+Layout/IndentFirstArrayElement:
   EnforcedStyle: consistent
-Layout/IndentHash:
+Layout/IndentFirstHashElement:
   EnforcedStyle: consistent
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A RuboCop extension to enforce common code style in Jekyll and Jekyll plugins.
 
 
 [![Gem Version](https://img.shields.io/gem/v/rubocop-jekyll.svg?label=Latest%20Release)][rubygems]
-[![RuboCop Support](https://img.shields.io/badge/Rubocop%20Support-0.57.2%20--%200.66.x-green.svg)][rubocop-releases]
+[![RuboCop Support](https://img.shields.io/badge/Rubocop%20Support-0.68.0%20--%200.69.x-green.svg)][rubocop-releases]
 
 [rubygems]: https://rubygems.org/gems/rubocop-jekyll
 [rubocop-releases]: https://github.com/rubocop-hq/rubocop/releases

--- a/rubocop-jekyll.gemspec
+++ b/rubocop-jekyll.gemspec
@@ -19,5 +19,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.required_ruby_version = ">= 2.3.0"
 
-  s.add_runtime_dependency "rubocop", ">= 0.57.2", "< 0.67.0"
+  s.add_runtime_dependency "rubocop", ">= 0.68.0", "< 0.70.0"
+  s.add_runtime_dependency "rubocop-performance", "~> 1.2"
 end


### PR DESCRIPTION
## Description
RuboCop v0.68.0 changed a couple of configuration keys and extracted `Performance` cops to a separate gem. So, the next release of `rubocop-jekyll` will not be compatible with RuboCop configs for versions older than `v0.68.0`.

### RuboCop Release Notes

RuboCop v0.68.0 Release Details: https://github.com/rubocop-hq/rubocop/releases/tag/v0.68.0
RuboCop v0.68.1 Release Details: https://github.com/rubocop-hq/rubocop/releases/tag/v0.68.1
RuboCop v0.69.0 Release Details: https://github.com/rubocop-hq/rubocop/releases/tag/v0.69.0