### PR TITLE
Allow using RuboCop v0.70.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A RuboCop extension to enforce common code style in Jekyll and Jekyll plugins.
 
 
 [![Gem Version](https://img.shields.io/gem/v/rubocop-jekyll.svg?label=Latest%20Release)][rubygems]
-[![RuboCop Support](https://img.shields.io/badge/Rubocop%20Support-0.68.0%20--%200.70.x-green.svg)][rubocop-releases]
+[![RuboCop Support](https://img.shields.io/badge/Rubocop%20Support-0.68.0%20--%200.71.x-green.svg)][rubocop-releases]
 
 [rubygems]: https://rubygems.org/gems/rubocop-jekyll
 [rubocop-releases]: https://github.com/rubocop-hq/rubocop/releases

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A RuboCop extension to enforce common code style in Jekyll and Jekyll plugins.
 
 
 [![Gem Version](https://img.shields.io/gem/v/rubocop-jekyll.svg?label=Latest%20Release)][rubygems]
-[![RuboCop Support](https://img.shields.io/badge/Rubocop%20Support-0.68.0%20--%200.69.x-green.svg)][rubocop-releases]
+[![RuboCop Support](https://img.shields.io/badge/Rubocop%20Support-0.68.0%20--%200.70.x-green.svg)][rubocop-releases]
 
 [rubygems]: https://rubygems.org/gems/rubocop-jekyll
 [rubocop-releases]: https://github.com/rubocop-hq/rubocop/releases

--- a/rubocop-jekyll.gemspec
+++ b/rubocop-jekyll.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.required_ruby_version = ">= 2.3.0"
 
-  s.add_runtime_dependency "rubocop", ">= 0.68.0", "< 0.70.0"
+  s.add_runtime_dependency "rubocop", ">= 0.68.0", "< 0.71.0"
   s.add_runtime_dependency "rubocop-performance", "~> 1.2"
 end

--- a/rubocop-jekyll.gemspec
+++ b/rubocop-jekyll.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.required_ruby_version = ">= 2.3.0"
 
-  s.add_runtime_dependency "rubocop", ">= 0.68.0", "< 0.71.0"
+  s.add_runtime_dependency "rubocop", ">= 0.68.0", "< 0.72.0"
   s.add_runtime_dependency "rubocop-performance", "~> 1.2"
 end


### PR DESCRIPTION
RuboCop v0.70.0 Release Details: https://github.com/rubocop-hq/rubocop/releases/tag/v0.70.0
RuboCop v0.71.0 Release Details: https://github.com/rubocop-hq/rubocop/releases/tag/v0.71.0

Closes #13 
