### PR TITLE
chore(deps): RuboCop v0.80.x

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -113,5 +113,3 @@ Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: consistent_comma
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: consistent_comma
-Style/WordArray:
-  EnforcedStyle: percent

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -114,4 +114,4 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: consistent_comma
 Style/WordArray:
-  EnforcedStyle: brackets
+  EnforcedStyle: percent

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,14 +11,16 @@ AllCops:
     - vendor/**/*
     - tmp/**/*
 
-
-Layout/AlignHash:
+Layout/LineLength:
+  Max: 100
+  Severity: warning
+Layout/HashAlignment:
   EnforcedHashRocketStyle: table
 Layout/IndentationWidth:
   Severity: error
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
@@ -41,9 +43,6 @@ Metrics/BlockLength:
     - !ruby/regexp /^spec/
 Metrics/ClassLength:
   Max: 240
-Metrics/LineLength:
-  Max: 100
-  Severity: warning
 Metrics/MethodLength:
   CountComments: false
   Max: 20
@@ -79,6 +78,12 @@ Style/GuardClause:
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
   Severity: error
+Style/HashEachMethods:
+  Enabled: true
+Style/HashTransformKeys:
+  Enabled: true
+Style/HashTransformValues:
+  Enabled: true
 Style/ModuleFunction:
   Enabled: false
 Style/MultilineTernaryOperator:
@@ -108,3 +113,5 @@ Style/TrailingCommaInArrayLiteral:
   EnforcedStyleForMultiline: consistent_comma
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: consistent_comma
+Style/WordArray:
+  EnforcedStyle: brackets

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,14 @@ env:
 - NWO="jekyll/jekyll-sitemap"
 - NWO="jekyll/jekyll-watch"
 - NWO="benbalter/jekyll-avatar"
+matrix:
+  # These repos are currently locked to rubocop-jekyll-0.10.x or older
+  allow_failures:
+    - env: NWO="jekyll/jekyll-admin"
+    - env: NWO="jekyll/jekyll-import"
+    - env: NWO="jekyll/jekyll-redirect-from"
+    - env: NWO="jekyll/jekyll-watch"
+    - env: NWO="benbalter/jekyll-avatar"
 branches:
   only:
   - master

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A RuboCop extension to enforce common code style in Jekyll and Jekyll plugins.
 
 
 [![Gem Version](https://img.shields.io/gem/v/rubocop-jekyll.svg?label=Latest%20Release)][rubygems]
-[![RuboCop Support](https://img.shields.io/badge/Rubocop%20Support-0.68.0%20--%200.71.x-green.svg)][rubocop-releases]
+[![RuboCop Support](https://img.shields.io/badge/Rubocop%20Support-0.68.0%20--%200.80.x-green.svg)][rubocop-releases]
 
 [rubygems]: https://rubygems.org/gems/rubocop-jekyll
 [rubocop-releases]: https://github.com/rubocop-hq/rubocop/releases

--- a/rubocop-jekyll.gemspec
+++ b/rubocop-jekyll.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.required_ruby_version = ">= 2.3.0"
 
-  s.add_runtime_dependency "rubocop", ">= 0.68.0", "< 0.72.0"
+  s.add_runtime_dependency "rubocop", ">= 0.68.0", "< 0.81.0"
   s.add_runtime_dependency "rubocop-performance", "~> 1.2"
 end


### PR DESCRIPTION
  - [x] The `master` branch of the Jekyll Repository has been updated to use the latest RuboCop release.
  - [x] updated ONLY the badge in the `README.md`.
  - [x] updated ONLY the RuboCop version in the `rubocop-jekyll.gemspec`.
  - [x] updated the `.rubocop.yml`

Rubocop Changelog: https://github.com/rubocop-hq/rubocop/releases

Tested on a few plugins and very minor changes so far.