### PR TITLE
Drop support for versions older than RuboCop 1.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,8 +11,12 @@ AllCops:
     - vendor/**/*
     - tmp/**/*
 
+Layout/BeginEndAlignment:
+  Enabled: true
 Layout/EmptyComment:
   Enabled: false
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
 Layout/EndAlignment:
   Severity: error
 Layout/FirstArrayElementIndentation:
@@ -30,19 +34,71 @@ Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: true
 
 
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: true
+Lint/ConstantDefinitionInBlock:
+  Enabled: true
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+Lint/DuplicateElsifCondition:
+  Enabled: true
+Lint/DuplicateRescueException:
+  Enabled: true
+Lint/DuplicateRequire:
+  Enabled: true
+Lint/EmptyConditionalBody:
+  Enabled: true
+Lint/EmptyFile:
+  Enabled: true
+Lint/FloatComparison:
+  Enabled: true
+Lint/HashCompareByIdentity:
+  Enabled: true
+Lint/IdentityComparison:
+  Enabled: true
+Lint/MissingSuper:
+  Enabled: false
+Lint/MixedRegexpCaptureTypes:
+  Enabled: false
+Lint/OutOfRangeRegexpRef:
+  Enabled: true
+Lint/RaiseException:
+  Enabled: true
+Lint/RedundantSafeNavigation:
+  Enabled: true
+Lint/SelfAssignment:
+  Enabled: true
+Lint/StructNewOverride:
+  Enabled: true
+Lint/TopLevelReturnWithArgument:
+  Enabled: true
+Lint/TrailingCommaInAttributeDeclaration:
+  Enabled: true
 Lint/UnreachableCode:
   Severity: error
+Lint/UnreachableLoop:
+  Enabled: true
+Lint/UselessMethodDefinition:
+  Enabled: true
+Lint/UselessTimes:
+  Enabled: true
 
 
 Metrics/AbcSize:
-  Max: 21
+  Max: 23
 Metrics/BlockLength:
   Exclude:
     - !ruby/regexp /^spec/
 Metrics/ClassLength:
   Max: 240
+Metrics/CyclomaticComplexity:
+  Max: 11
 Metrics/MethodLength:
   CountComments: false
   Max: 20
@@ -52,7 +108,7 @@ Metrics/ModuleLength:
 Metrics/ParameterLists:
   Max: 4
 Metrics/PerceivedComplexity:
-  Max: 8
+  Max: 13
 
 
 Naming/FileName:
@@ -61,33 +117,81 @@ Naming/MemoizedInstanceVariableName:
   EnforcedStyleForLeadingUnderscores: optional
 
 
+Performance/AncestorsInclude:
+  Enabled: false
+Performance/BigDecimalWithNumericArgument:
+  Enabled: true
+Performance/ChainArrayAllocation:
+  Enabled: true
+Performance/RedundantSortBlock:
+  Enabled: true
+Performance/RedundantStringChars:
+  Enabled: true
+Performance/ReverseFirst:
+  Enabled: true
+Performance/SortReverse:
+  Enabled: false
+Performance/Squeeze:
+  Enabled: true
+Performance/StringInclude:
+  Enabled: true
+Performance/Sum:
+  Enabled: true
+
+
+Style/ArrayCoercion:
+  Enabled: true
 Style/AccessModifierDeclarations:
+  Enabled: false
+Style/AccessorGrouping:
   Enabled: false
 Style/Alias:
   EnforcedStyle: prefer_alias_method
 Style/AndOr:
   Severity: error
+Style/BisectedAttrAccessor:
+  Enabled: true
+Style/CaseLikeIf:
+  Enabled: true
+Style/ClassEqualityComparison:
+  Enabled: true
+Style/CombinableLoops:
+  Enabled: true
 Style/Documentation:
   Enabled: false
 Style/DoubleNegation:
   Enabled: false
+Style/ExponentialNotation:
+  Enabled: true
+Style/ExplicitBlockArgument:
+  Enabled: false
 Style/FrozenStringLiteralComment:
   EnforcedStyle: always
+Style/GlobalStdStream:
+  Enabled: true
 Style/GuardClause:
   Enabled: false
+Style/HashAsLastArrayItem:
+  Enabled: true
 Style/HashEachMethods:
+  Enabled: true
+Style/HashLikeCase:
   Enabled: true
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
   Severity: error
 Style/HashTransformKeys:
-  Enabled: true
+  Enabled: false
 Style/HashTransformValues:
+  Enabled: true
+Style/KeywordParametersOrder:
   Enabled: true
 Style/ModuleFunction:
   Enabled: false
 Style/MultilineTernaryOperator:
   Severity: error
+Style/OptionalBooleanParameter:
+  Enabled: true
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     "%q": "{}"
@@ -97,14 +201,34 @@ Style/PercentLiteralDelimiters:
     "%w": "()"
     "%W": "()"
     "%x": "()"
+Style/RedundantAssignment:
+  Enabled: true
+Style/RedundantFetchBlock:
+  Enabled: false
+Style/RedundantFileExtensionInRequire:
+  Enabled: true
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+Style/RedundantRegexpEscape:
+  Enabled: true
+Style/RedundantSelfAssignment:
+  Enabled: true
 Style/RegexpLiteral:
   EnforcedStyle: percent_r
 Style/RescueModifier:
   Enabled: false
 Style/SignalException:
   EnforcedStyle: only_raise
+Style/SingleArgumentDig:
+  Enabled: true
+Style/SlicingWithRange:
+  Enabled: false
+Style/SoleNestedConditional:
+  Enabled: true
 Style/StringLiterals:
   EnforcedStyle: double_quotes
+Style/StringConcatenation:
+  Enabled: true
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
 Style/SymbolArray:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,25 +11,25 @@ AllCops:
     - vendor/**/*
     - tmp/**/*
 
-Layout/LineLength:
-  Max: 100
-  Severity: warning
-Layout/HashAlignment:
-  EnforcedHashRocketStyle: table
-Layout/IndentationWidth:
+Layout/EmptyComment:
+  Enabled: false
+Layout/EndAlignment:
   Severity: error
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
+Layout/HashAlignment:
+  EnforcedHashRocketStyle: table
+Layout/IndentationWidth:
+  Severity: error
+Layout/LineLength:
+  Max: 100
+  Severity: warning
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
-Layout/EmptyComment:
-  Enabled: false
-Layout/EndAlignment:
-  Severity: error
 
 
 Lint/UnreachableCode:
@@ -67,19 +67,19 @@ Style/Alias:
   EnforcedStyle: prefer_alias_method
 Style/AndOr:
   Severity: error
-Style/FrozenStringLiteralComment:
-  EnforcedStyle: always
 Style/Documentation:
   Enabled: false
 Style/DoubleNegation:
   Enabled: false
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: always
 Style/GuardClause:
   Enabled: false
+Style/HashEachMethods:
+  Enabled: true
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
   Severity: error
-Style/HashEachMethods:
-  Enabled: true
 Style/HashTransformKeys:
   Enabled: true
 Style/HashTransformValues:

--- a/rubocop-jekyll.gemspec
+++ b/rubocop-jekyll.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.required_ruby_version = ">= 2.3.0"
 
-  s.add_runtime_dependency "rubocop", ">= 0.68.0", "< 0.81.0"
-  s.add_runtime_dependency "rubocop-performance", "~> 1.2"
+  s.add_runtime_dependency "rubocop", "~> 1.0"
+  s.add_runtime_dependency "rubocop-performance", "~> 1.8"
 end


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please ensure that the following requirements are met:
  - Current version constraint does not allow using the latest RuboCop release.
  - The `master` branch of the Jekyll Repository has been updated to use the latest RuboCop release.

  Checklist:
  - Has updated ONLY the badge in the `README.md`.
  - Has updated ONLY the RuboCop version in the `rubocop-jekyll.gemspec`.
  - [OPTIONAL] Has updated the `.rubocop.yml`
-->

<!--
  Replace [RUBOCOP-VERSION] below with valid information. e.g. Allowing the use of RuboCop-0.63.0 would be:

    RuboCop v0.63.0 Release Details: https://github.com/rubocop-hq/rubocop/releases/tag/v0.63.0

  If there is an intermediate RuboCop version, refer to that version as well. e.g. When bumping directly from
  v0.62.x to v0.63.1:

    RuboCop v0.63.0 Release Details: https://github.com/rubocop-hq/rubocop/releases/tag/v0.63.0
    RuboCop v0.63.1 Release Details: https://github.com/rubocop-hq/rubocop/releases/tag/v0.63.1
-->

RuboCop v1.0.0 Release Details: https://github.com/rubocop-hq/rubocop/releases/tag/v1.0.0
