### PR TITLE
Require RuboCop v1.18.x

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ require:
   - rubocop-performance
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.5
   Exclude:
     - bin/**/*
     - exe/**/*
@@ -11,29 +11,125 @@ AllCops:
     - vendor/**/*
     - tmp/**/*
 
-Layout/LineLength:
-  Max: 100
-  Severity: warning
-Layout/HashAlignment:
-  EnforcedHashRocketStyle: table
-Layout/IndentationWidth:
+Gemspec/DateAssignment:
+  Enabled: true
+
+
+Layout/BeginEndAlignment:
+  Enabled: true
+Layout/EmptyComment:
+  Enabled: false
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+Layout/EndAlignment:
   Severity: error
 Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
+Layout/HashAlignment:
+  EnforcedHashRocketStyle: table
+Layout/IndentationWidth:
+  Severity: error
+Layout/LineLength:
+  Max: 100
+  Severity: warning
 Layout/MultilineMethodCallIndentation:
   EnforcedStyle: indented
 Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
-Layout/EmptyComment:
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+Layout/SpaceBeforeBrackets:
+  Enabled: true
+Layout/SpaceInsideHashLiteralBraces:
+  Enabled: true
+
+
+Lint/AmbiguousAssignment:
+  Enabled: true
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: true
+Lint/ConstantDefinitionInBlock:
+  Enabled: true
+Lint/DeprecatedConstants:
+  Enabled: true
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+Lint/DuplicateBranch:
+  Enabled: true
+Lint/DuplicateElsifCondition:
+  Enabled: true
+Lint/DuplicateRegexpCharacterClassElement:
+  Enabled: true
+Lint/DuplicateRequire:
+  Enabled: true
+Lint/DuplicateRescueException:
+  Enabled: true
+Lint/EmptyBlock:
+  Enabled: true
+Lint/EmptyClass:
+  Enabled: true
+Lint/EmptyConditionalBody:
+  Enabled: true
+Lint/EmptyFile:
+  Enabled: true
+Lint/FloatComparison:
+  Enabled: true
+Lint/HashCompareByIdentity:
+  Enabled: true
+Lint/IdentityComparison:
+  Enabled: true
+Lint/LambdaWithoutLiteralBlock:
+  Enabled: true
+Lint/MissingSuper:
   Enabled: false
-Layout/EndAlignment:
-  Severity: error
-
-
+Lint/MixedRegexpCaptureTypes:
+  Enabled: false
+Lint/NestedPercentLiteral:
+  Enabled: true
+Lint/NoReturnInBeginEndBlocks:
+  Enabled: true
+Lint/NumberedParameterAssignment:
+  Enabled: true
+Lint/OrAssignmentToConstant:
+  Enabled: true
+Lint/OutOfRangeRegexpRef:
+  Enabled: true
+Lint/RaiseException:
+  Enabled: true
+Lint/RedundantDirGlobSort:
+  Enabled: true
+Lint/RedundantSafeNavigation:
+  Enabled: true
+Lint/SelfAssignment:
+  Enabled: true
+Lint/StructNewOverride:
+  Enabled: true
+Lint/SymbolConversion:
+  Enabled: true
+Lint/ToEnumArguments:
+  Enabled: false
+Lint/TopLevelReturnWithArgument:
+  Enabled: true
+Lint/TrailingCommaInAttributeDeclaration:
+  Enabled: true
+Lint/TripleQuotes:
+  Enabled: true
+Lint/UnexpectedBlockArity:
+  Enabled: true
+Lint/UnmodifiedReduceAccumulator:
+  Enabled: true
 Lint/UnreachableCode:
   Severity: error
+Lint/UnreachableLoop:
+  Enabled: true
+Lint/UselessMethodDefinition:
+  Enabled: true
+Lint/UselessTimes:
+  Enabled: true
+Lint/Void:
+  Enabled: true
 
 
 Metrics/AbcSize:
@@ -61,33 +157,117 @@ Naming/MemoizedInstanceVariableName:
   EnforcedStyleForLeadingUnderscores: optional
 
 
+Performance/AncestorsInclude:
+  Enabled: false
+Performance/ArraySemiInfiniteRangeSlice:
+  Enabled: true
+Performance/BigDecimalWithNumericArgument:
+  Enabled: true
+Performance/BlockGivenWithExplicitBlock:
+  Enabled: true
+Performance/ChainArrayAllocation:
+  Enabled: true
+Performance/CollectionLiteralInLoop:
+  Enabled: true
+Performance/ConstantRegexp:
+  Enabled: true
+Performance/MethodObjectAsBlock:
+  Enabled: true
+Performance/RedundantSortBlock:
+  Enabled: true
+Performance/RedundantStringChars:
+  Enabled: true
+Performance/ReverseFirst:
+  Enabled: true
+Performance/SortReverse:
+  Enabled: false
+Performance/Squeeze:
+  Enabled: true
+Performance/StringInclude:
+  Enabled: true
+Performance/Sum:
+  Enabled: true
+
+
 Style/AccessModifierDeclarations:
   Enabled: false
+Style/AccessorGrouping:
+  Enabled: true
 Style/Alias:
   EnforcedStyle: prefer_alias_method
 Style/AndOr:
   Severity: error
-Style/FrozenStringLiteralComment:
-  EnforcedStyle: always
+Style/ArgumentsForwarding:
+  Enabled: false
+Style/ArrayCoercion:
+  Enabled: true
+Style/BisectedAttrAccessor:
+  Enabled: true
+Style/CaseLikeIf:
+  Enabled: true
+Style/StringChars:
+  Enabled: true
+Style/ClassAndModuleChildren:
+  Enabled: true
+Style/ClassEqualityComparison:
+  Enabled: true
+Style/CollectionCompact:
+  Enabled: true
+Style/CombinableLoops:
+  Enabled: true
+Style/DocumentDynamicEvalDefinition:
+  Enabled: true
 Style/Documentation:
   Enabled: false
 Style/DoubleNegation:
   Enabled: false
+Style/EndlessMethod:
+  Enabled: true
+Style/ExplicitBlockArgument:
+  Enabled: false
+Style/ExponentialNotation:
+  Enabled: true
+Style/FormatStringToken:
+  Enabled: true
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: always
+Style/GlobalStdStream:
+  Enabled: true
 Style/GuardClause:
   Enabled: false
+Style/HashAsLastArrayItem:
+  Enabled: true
+Style/HashConversion:
+  Enabled: true
+Style/HashEachMethods:
+  Enabled: true
+Style/HashExcept:
+  Enabled: true
+Style/HashLikeCase:
+  Enabled: true
 Style/HashSyntax:
   EnforcedStyle: hash_rockets
   Severity: error
-Style/HashEachMethods:
-  Enabled: true
 Style/HashTransformKeys:
-  Enabled: true
+  Enabled: false
 Style/HashTransformValues:
+  Enabled: true
+Style/IfWithBooleanLiteralBranches:
+  Enabled: true
+Style/KeywordParametersOrder:
+  Enabled: true
+Style/MixinUsage:
   Enabled: true
 Style/ModuleFunction:
   Enabled: false
 Style/MultilineTernaryOperator:
   Severity: error
+Style/NegatedIfElseCondition:
+  Enabled: true
+Style/NilLambda:
+  Enabled: true
+Style/OptionalBooleanParameter:
+  Enabled: true
 Style/PercentLiteralDelimiters:
   PreferredDelimiters:
     "%q": "{}"
@@ -97,16 +277,42 @@ Style/PercentLiteralDelimiters:
     "%w": "()"
     "%W": "()"
     "%x": "()"
+Style/RedundantArgument:
+  Enabled: true
+Style/RedundantAssignment:
+  Enabled: true
+Style/RedundantFetchBlock:
+  Enabled: false
+Style/RedundantFileExtensionInRequire:
+  Enabled: true
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+Style/RedundantRegexpEscape:
+  Enabled: true
+Style/RedundantSelfAssignment:
+  Enabled: true
 Style/RegexpLiteral:
   EnforcedStyle: percent_r
 Style/RescueModifier:
   Enabled: false
+Style/SafeNavigation:
+  Enabled: true
 Style/SignalException:
   EnforcedStyle: only_raise
+Style/SingleArgumentDig:
+  Enabled: true
+Style/SlicingWithRange:
+  Enabled: false
+Style/SoleNestedConditional:
+  Enabled: true
+Style/StringConcatenation:
+  Enabled: true
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 Style/StringLiteralsInInterpolation:
   EnforcedStyle: double_quotes
+Style/SwapValues:
+  Enabled: true
 Style/SymbolArray:
   EnforcedStyle: brackets
 Style/TrailingCommaInArrayLiteral:

--- a/lib/rubocop-jekyll.rb
+++ b/lib/rubocop-jekyll.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 
 path_to_cops = File.join(File.expand_path("rubocop", __dir__), "cop", "**", "*.rb")
-Dir[path_to_cops].each { |cop| require cop }
+Dir[path_to_cops].sort.each { |cop| require cop }

--- a/rubocop-jekyll.gemspec
+++ b/rubocop-jekyll.gemspec
@@ -17,8 +17,8 @@ Gem::Specification.new do |s|
   end
 
   s.require_paths = ["lib"]
-  s.required_ruby_version = ">= 2.3.0"
+  s.required_ruby_version = ">= 2.5.0"
 
-  s.add_runtime_dependency "rubocop", ">= 0.68.0", "< 0.81.0"
+  s.add_runtime_dependency "rubocop", "~> 1.18.0"
   s.add_runtime_dependency "rubocop-performance", "~> 1.2"
 end


### PR DESCRIPTION
<!--
  Thanks for creating a Pull Request! Before you submit, please ensure that the following requirements are met:
  - Current version constraint does not allow using the latest RuboCop release.
  - The `master` branch of the Jekyll Repository has been updated to use the latest RuboCop release.

  Checklist:
  - Has updated ONLY the badge in the `README.md`.
  - Has updated ONLY the RuboCop version in the `rubocop-jekyll.gemspec`.
  - [OPTIONAL] Has updated the `.rubocop.yml`
-->

<!--
  Replace [RUBOCOP-VERSION] below with valid information. e.g. Allowing the use of RuboCop-0.63.0 would be:

    RuboCop v0.63.0 Release Details: https://github.com/rubocop-hq/rubocop/releases/tag/v0.63.0

  If there is an intermediate RuboCop version, refer to that version as well. e.g. When bumping directly from
  v0.62.x to v0.63.1:

    RuboCop v0.63.0 Release Details: https://github.com/rubocop-hq/rubocop/releases/tag/v0.63.0
    RuboCop v0.63.1 Release Details: https://github.com/rubocop-hq/rubocop/releases/tag/v0.63.1

RuboCop v[RUBOCOP-VERSION] Release Details: https://github.com/rubocop-hq/rubocop/releases/tag/v[RUBOCOP-VERSION]
-->

Upgrade from **`RuboCop v0.80`** to **`RuboCop v1.18.x`**. (The current version used at `jekyll/jekyll`)

- Changes to `.rubocop.yml` are as per the current state of the config file at `jekyll/jekyll`.
- Requires at least Ruby 2.5.0
